### PR TITLE
Fix SCSS mixin imports

### DIFF
--- a/src/styles/App.module.scss
+++ b/src/styles/App.module.scss
@@ -1,4 +1,4 @@
-@use "partials/global";
+@use "./partials/global";
 
 :root {
   background-color: black;

--- a/src/styles/Icon.module.scss
+++ b/src/styles/Icon.module.scss
@@ -1,3 +1,3 @@
-@use "partials/global";
+@use "./partials/global";
 
 .main {}

--- a/src/styles/Index.module.scss
+++ b/src/styles/Index.module.scss
@@ -1,1 +1,1 @@
-@use "partials/global";
+@use "./partials/global";

--- a/src/styles/NavCentre.module.scss
+++ b/src/styles/NavCentre.module.scss
@@ -1,4 +1,4 @@
-@use "partials/global" as *;
+@use "./partials/global" as *;
 
 .navCentreMain {
   display: flex;

--- a/src/styles/NavEnd.module.scss
+++ b/src/styles/NavEnd.module.scss
@@ -1,4 +1,4 @@
-@use "partials/global" as *;
+@use "./partials/global" as *;
 
 .main {
   @include flex-center(row);

--- a/src/styles/NavIcon.module.scss
+++ b/src/styles/NavIcon.module.scss
@@ -1,4 +1,4 @@
-@use "partials/global";
+@use "./partials/global";
 
 .main {
   display: flex;

--- a/src/styles/Navbar.module.scss
+++ b/src/styles/Navbar.module.scss
@@ -1,4 +1,4 @@
-@use "partials/global";
+@use "./partials/global";
 
 .nav {
   padding: 8px;

--- a/src/styles/SearchBar.module.scss
+++ b/src/styles/SearchBar.module.scss
@@ -1,4 +1,4 @@
-@use "partials/global";
+@use "./partials/global";
 
 .main {
   display: flex;

--- a/src/styles/Tooltip.module.scss
+++ b/src/styles/Tooltip.module.scss
@@ -1,4 +1,4 @@
-@use "partials/global" as *;
+@use "./partials/global" as *;
 
 .wrapper {
   display: flex;

--- a/src/styles/partials/_global.scss
+++ b/src/styles/partials/_global.scss
@@ -1,4 +1,4 @@
-@use "index" as *;
+@use "./index" as *;
 
 
 .test-check {

--- a/src/styles/partials/_index.scss
+++ b/src/styles/partials/_index.scss
@@ -1,2 +1,2 @@
-@forward "mixins";
-@forward "fonts";
+@forward "./mixins";
+@forward "./fonts";


### PR DESCRIPTION
## Summary
- use relative paths for SCSS partials

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx sass src/styles/NavEnd.module.scss` *(fails: 403 Forbidden - GET https://registry.npmjs.org/sass)*

------
https://chatgpt.com/codex/tasks/task_e_687cd7349a1883318554d43b7c10e96d